### PR TITLE
Fix PFSenseModule::is_version() to resolve problems under pfsense+ 22.02

### DIFF
--- a/plugins/module_utils/pfsense.py
+++ b/plugins/module_utils/pfsense.py
@@ -657,6 +657,9 @@ class PFSenseModule(object):
         for idx, ver in enumerate(version):
             if idx == len(self.pfsense_version):
                 return True
+                
+            if self.pfsense_version[idx] > ver and or_more:
+                return True
 
             if ver < self.pfsense_version[idx] and not or_more or ver > self.pfsense_version[idx]:
                 return False

--- a/plugins/module_utils/pfsense.py
+++ b/plugins/module_utils/pfsense.py
@@ -657,7 +657,6 @@ class PFSenseModule(object):
         for idx, ver in enumerate(version):
             if idx == len(self.pfsense_version):
                 return True
-                
             if self.pfsense_version[idx] > ver and or_more:
                 return True
 


### PR DESCRIPTION
pfsense version: 22.02

Bug: When using pfsense+ 22.02, [PFSenseModule::is_at_least_2_5_0()](https://github.com/pfsensible/core/blob/99396a52f72c6267a2a08cd271bc3386b224a4b3/plugins/module_utils/pfsense.py#L666) return `False` and lead to choosing wrong branch  e.g. [PFSenseVlanModule](https://github.com/pfsensible/core/blob/99aed7648a95adb20b80a65302575b00bc01ecf9/plugins/module_utils/vlan.py#L55). 

The reason is that the [PFSenseModule::is_version()](https://github.com/pfsensible/core/blob/99396a52f72c6267a2a08cd271bc3386b224a4b3/plugins/module_utils/pfsense.py#L657) return False when the current major version > target major version and current minor version < target minor version

The fix: Return `True` when the current major version > target major version.
