### PR TITLE
fix(pfsense-cert): add RSA PRIVATE KEY support

### DIFF
--- a/plugins/modules/pfsense_cert.py
+++ b/plugins/modules/pfsense_cert.py
@@ -240,7 +240,7 @@ class PFSenseCertModule(PFSenseModuleBase):
         if params['key'] is not None:
             key = params['key']
             lines = key.splitlines()
-            if lines[0] == '-----BEGIN PRIVATE KEY-----' and lines[-1] == '-----END PRIVATE KEY-----':
+            if re.match('^-----BEGIN (RSA )?PRIVATE KEY-----$', lines[0]) and re.match('^-----END (RSA )?PRIVATE KEY-----$', lines[-1]):
                 params['key'] = base64.b64encode(key.encode()).decode()
             elif not re.match('LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0t', key):
                 self.module.fail_json(msg='Could not recognize key format: %s' % (key))


### PR DESCRIPTION
pfsense also can handle Keys with RSA start and end lines