### PR TITLE
Closes #77

### DIFF
--- a/plugins/module_utils/openvpn_override.py
+++ b/plugins/module_utils/openvpn_override.py
@@ -121,10 +121,6 @@ class PFSenseOpenVPNOverrideModule(PFSenseModuleBase):
         # check name
         self.pfsense.validate_string(params['name'], 'openvpn_override')
 
-        if params.get('tunnel_network') and not self.pfsense.is_ipv4_network(params['tunnel_network']):
-            self.module.fail_json(msg='A valid IPv4 network must be specified for tunnel_network.')
-        if params.get('tunnel_network6') and not self.pfsense.is_ipv6_network(params['tunnel_networkv6']):
-            self.module.fail_json(msg='A valid IPv6 network must be specified for tunnel_network6.')
         if params.get('local_network') and not self.pfsense.is_ipv4_network(params['local_network']):
             self.module.fail_json(msg='A valid IPv4 network must be specified for local_network.')
         if params.get('local_network6') and not self.pfsense.is_ipv6_network(params['local_networkv6']):


### PR DESCRIPTION
removed network checks for tunnel_network and tunnel_network6 as they should be allowed to specify non-network addresses to have static client ip addresses. This is in line with how the pfsense GUI works and even in line with the examples provided by the pfsense GUI.

