### PR TITLE
fw support floating 'all' interface rule

### DIFF
--- a/plugins/module_utils/rule.py
+++ b/plugins/module_utils/rule.py
@@ -154,7 +154,10 @@ class PFSenseRuleModule(PFSenseModuleBase):
         """ validate param interface field when floating is true """
         res = []
         for interface in interfaces.split(','):
-            res.append(self.pfsense.parse_interface(interface))
+            if interface == 'any':
+                res.append(interface)
+            else:
+                res.append(self.pfsense.parse_interface(interface))
         self._floating_interfaces = interfaces
         return ','.join(res)
 

--- a/plugins/modules/pfsense_rule.py
+++ b/plugins/modules/pfsense_rule.py
@@ -42,7 +42,7 @@ options:
     default: false
     type: bool
   interface:
-    description: The interface for the rule
+    description: The interface for the rule. Use 'any' to apply to all interface (for floating rules only).
     required: true
     type: str
   floating:

--- a/tests/unit/plugins/modules/test_pfsense_rule_create.py
+++ b/tests/unit/plugins/modules/test_pfsense_rule_create.py
@@ -66,6 +66,17 @@ class TestPFSenseRuleCreateModule(TestPFSenseRuleModule):
         command = "create rule 'one_rule' on 'floating(lan)', source='any', destination='any', direction='any'"
         self.do_module_test(obj, command=command)
 
+    def test_rule_create_floating_any(self):
+        """ test creation of a new floating rule with any interface """
+        obj = dict(name='one_rule', source='any', destination='any', interface='any', floating='yes', direction='any')
+        command = "create rule 'one_rule' on 'floating(any)', source='any', destination='any', direction='any'"
+
+    def test_rule_create_non_floating_any(self):
+        """ test creation of a new rule with any interface """
+        obj = dict(name='one_rule', source='any', destination='any', interface='any', floating='no', direction='any')
+        msg = "any is not a valid interface"
+        self.do_module_test(obj, failed=True, msg=msg)
+
     def test_rule_create_floating_quick(self):
         """ test creation of a new floating rule with quick match """
         obj = dict(name='one_rule', source='any', destination='any', interface='lan', floating='yes', direction='any', quick='yes')


### PR DESCRIPTION
Add support for 'All' interface when creating floating firewall rule

Before
![изображение](https://github.com/pfsensible/core/assets/109062285/af27493e-1742-48c3-b950-3747cf829719)


After
![изображение](https://github.com/pfsensible/core/assets/109062285/f40c7593-b4b8-4d38-8bfb-1e56aefe4b41)
![изображение](https://github.com/pfsensible/core/assets/109062285/a4840f0b-d876-4b3e-aee1-6f529d060c74)

