### PR TITLE
Change strictusercn option

### DIFF
--- a/plugins/module_utils/openvpn_client.py
+++ b/plugins/module_utils/openvpn_client.py
@@ -29,7 +29,7 @@ OPENVPN_CLIENT_ARGUMENT_SPEC = dict(
     crl=dict(required=False, type='str'),
     cert=dict(required=False, type='str'),
     cert_depth=dict(default=1, required=False, type='int'),
-    strictuserdn=dict(default=False, required=False, type='bool'),
+    strictusercn=dict(default=False, required=False, type='bool'),
     shared_key=dict(required=False, type='str', no_log=True),
     dh_length=dict(default=2048, required=False, type='int'),
     ecdh_curve=dict(default='none', required=False, choices=['none', 'prime256v1', 'secp384r1', 'secp521r1']),
@@ -107,7 +107,7 @@ class PFSenseOpenVPNClientModule(PFSenseModuleBase):
         if self.params['state'] == 'present':
             obj['custom_options'] = self.params['custom_options']
             self._get_ansible_param_bool(obj, 'disable')
-            self._get_ansible_param_bool(obj, 'strictuserdn')
+            self._get_ansible_param_bool(obj, 'strictusercn')
             obj['mode'] = self.params['mode']
             obj['dev_mode'] = self.params['dev_mode']
             obj['interface'] = self.params['interface']

--- a/plugins/module_utils/openvpn_server.py
+++ b/plugins/module_utils/openvpn_server.py
@@ -29,7 +29,7 @@ OPENVPN_SERVER_ARGUMENT_SPEC = dict(
     crl=dict(required=False, type='str'),
     cert=dict(required=False, type='str'),
     cert_depth=dict(default=1, required=False, type='int'),
-    strictuserdn=dict(default=False, required=False, type='bool'),
+    strictusercn=dict(default=False, required=False, type='bool'),
     shared_key=dict(required=False, type='str', no_log=True),
     dh_length=dict(default=2048, required=False, type='int'),
     ecdh_curve=dict(default='none', required=False, choices=['none', 'prime256v1', 'secp384r1', 'secp521r1']),
@@ -119,7 +119,7 @@ class PFSenseOpenVPNServerModule(PFSenseModuleBase):
         if self.params['state'] == 'present':
             obj['custom_options'] = self.params['custom_options']
             self._get_ansible_param_bool(obj, 'disable')
-            self._get_ansible_param_bool(obj, 'strictuserdn')
+            self._get_ansible_param_bool(obj, 'strictusercn')
             obj['mode'] = self.params['mode']
             obj['dev_mode'] = self.params['dev_mode']
             obj['interface'] = self.params['interface']
@@ -275,7 +275,7 @@ class PFSenseOpenVPNServerModule(PFSenseModuleBase):
     def _get_params_to_remove(self):
         """ returns the list of params to remove if they are not set """
         params_to_remove = []
-        for param in ['disable', 'strictuserdn', 'push_register_dns']:
+        for param in ['disable', 'strictusercn', 'push_register_dns']:
             if not self.params[param]:
                 params_to_remove.append(param)
 

--- a/plugins/modules/pfsense_openvpn_client.py
+++ b/plugins/modules/pfsense_openvpn_client.py
@@ -82,7 +82,7 @@ options:
     required: false
     default: 1
     type: int
-  strictuserdn:
+  strictusercn:
     description: Enforce a match between the common name of the client certificate and the username given at login.
     default: false
     type: bool

--- a/plugins/modules/pfsense_openvpn_server.py
+++ b/plugins/modules/pfsense_openvpn_server.py
@@ -85,7 +85,7 @@ options:
     required: false
     default: 1
     type: int
-  strictuserdn:
+  strictusercn:
     description: Enforce a match between the common name of the client certificate and the username given at login.
     default: false
     type: bool


### PR DESCRIPTION
I worked with this module but when I want to use the "strictuserdn" options in the openvpn server module, it can't work very fine. I can't check or uncheck this option by this module. 

After check on my side, I have seen a difference between the openvpn server config name and the option name. That's why I tried to change the name, and it works fine after the change. 

May could I open an issue for that ? 
