### PR TITLE
add some more documentation for pfsense_openvpn_server examples

### DIFF
--- a/plugins/modules/pfsense_openvpn_server.py
+++ b/plugins/modules/pfsense_openvpn_server.py
@@ -257,6 +257,27 @@ EXAMPLES = """
 - name: "Add OpenVPN server"
   pfsense_openvpn_server:
     name: 'OpenVPN Server'
+    mode: server_user
+
+- name: "Add OpenVPN server with basic configuration"
+  pfsense_openvpn_server:
+    name: 'OpenVPN Server Ansible'
+    ca: name-your-ca-authority
+    cert: name-your-server-certificate
+    tunnel_network: 10.21.40.0/24
+    local_network: 172.16.3.0/24
+    mode: server_tls_user
+
+- name: "Add OpenVPN server with verbose mode and Cloudflare DNS"
+  pfsense_openvpn_server:
+    name: 'OpenVPN Server Ansible Cloudflare'
+    ca: name-your-ca-authority
+    cert: name-your-server-certificate
+    tunnel_network: 10.10.10.0/24
+    local_network: 10.72.40.0/24
+    dns_server1: 1.1.1.1
+    verbosity_level: 4
+    mode: server_user
 """
 
 RETURN = r'''


### PR DESCRIPTION
The unique actual example of thepfsense_openvpn_server module  is not complet,  as mode is needed. Also two more examples are added to complete the documentation for this quick "copy and paste" for new users. 