### PR TITLE
Feature: Add few missing entry support to openvpn_server

### DIFF
--- a/plugins/module_utils/openvpn_server.py
+++ b/plugins/module_utils/openvpn_server.py
@@ -30,6 +30,7 @@ OPENVPN_SERVER_ARGUMENT_SPEC = dict(
     cert=dict(required=False, type='str'),
     cert_depth=dict(default=1, required=False, type='int'),
     strictusercn=dict(default=False, required=False, type='bool'),
+    remote_cert_tls=dict(default=False, required=False, type='bool'),
     shared_key=dict(required=False, type='str', no_log=True),
     dh_length=dict(default=2048, required=False, type='int'),
     ecdh_curve=dict(default='none', required=False, choices=['none', 'prime256v1', 'secp384r1', 'secp521r1']),
@@ -56,6 +57,10 @@ OPENVPN_SERVER_ARGUMENT_SPEC = dict(
     client2client=dict(default=False, required=False, type='bool'),
     dynamic_ip=dict(default=False, required=False, type='bool'),
     topology=dict(default='subnet', required=False, choices=['net30', 'subnet']),
+    inactive_seconds=dict(default=0, required=False, type='int'),
+    keepalive_interval=dict(default=10, required=False, type='int'),
+    keepalive_timeout=dict(default=60, required=False, type='int'),
+    exit_notify=dict(default='', required=False, choices=['', '1', '2']),
     dns_domain=dict(default='', required=False, type='str'),
     dns_server1=dict(default='', required=False, type='str'),
     dns_server2=dict(default='', required=False, type='str'),
@@ -120,6 +125,7 @@ class PFSenseOpenVPNServerModule(PFSenseModuleBase):
             obj['custom_options'] = self.params['custom_options']
             self._get_ansible_param_bool(obj, 'disable')
             self._get_ansible_param_bool(obj, 'strictusercn')
+            self._get_ansible_param_bool(obj, 'remote_cert_tls')
             obj['mode'] = self.params['mode']
             obj['dev_mode'] = self.params['dev_mode']
             obj['interface'] = self.params['interface']
@@ -148,6 +154,10 @@ class PFSenseOpenVPNServerModule(PFSenseModuleBase):
             obj['allow_compression'] = self.params['allow_compression']
             obj['compression'] = self.params['compression']
             obj['topology'] = self.params['topology']
+            self._get_ansible_param(obj, 'inactive_seconds')
+            self._get_ansible_param(obj, 'keepalive_interval')
+            self._get_ansible_param(obj, 'keepalive_timeout')
+            obj['exit_notify'] = self.params['exit_notify']
             obj['create_gw'] = self.params['create_gw']
 
             if 'user' in self.params['mode']:
@@ -285,7 +295,7 @@ class PFSenseOpenVPNServerModule(PFSenseModuleBase):
     def _get_params_to_remove(self):
         """ returns the list of params to remove if they are not set """
         params_to_remove = []
-        for param in ['disable', 'strictusercn', 'push_register_dns']:
+        for param in ['disable', 'strictusercn', 'push_register_dns', 'remote_cert_tls']:
             if not self.params[param]:
                 params_to_remove.append(param)
 

--- a/plugins/modules/pfsense_openvpn_server.py
+++ b/plugins/modules/pfsense_openvpn_server.py
@@ -91,6 +91,10 @@ options:
     description: Enforce a match between the common name of the client certificate and the username given at login.
     default: false
     type: bool
+  remote_cert_tls:
+    description: Enforce that only hosts with a client certificate can connect (EKU: "TLS Web Client Authentication").
+    default: false
+    type: bool
   shared_key:
     description: Pre-shared key for shared key modes.  If set to 'generate' it will create a key if one does not already exist.
     type: str
@@ -208,6 +212,35 @@ options:
     description: The method used to supply a virtual adapter IP address to clients when using TUN mode on IPv4.
     default: subnet
     choices: ['net30', 'subnet']
+    type: str
+  inactive_seconds:
+    description: Causes OpenVPN to close a client connection after n seconds of inactivity on the TUN/TAP device.
+    default: 0
+    type: int
+  keepalive_interval:
+    description:
+      - keepalive helper uses interval and timeout parameters to define ping and ping-restart values as follows:
+      - ping = interval
+      - ping-restart = timeout*2
+      - push ping = interval
+      - push ping-restart = timeout
+    default: 10
+    type: int
+  keepalive_timeout:
+    description:
+      - keepalive helper uses interval and timeout parameters to define ping and ping-restart values as follows:
+      - ping = interval
+      - ping-restart = timeout*2
+      - push ping = interval
+      - push ping-restart = timeout
+    default: 60
+    type: int
+  exit_notify:
+    description: 
+      - Send an explicit exit notification to connected clients/peers when restarting or shutting down.
+      - So they may immediately disconnect rather than waiting for a timeout.
+    default: ''
+    choices: ['', '1', '2']
     type: str
   dns_domain:
     description: DNS default domain.


### PR DESCRIPTION
This commit will add remote_cert_tls, inactive_seconds, keepalive_interval, keepalive_timeout and exit_notify features to pfsensible.core.pfsense_openvpn_server module