### PR TITLE
[pfsense_openvpn_client/server] TLS fixes

### DIFF
--- a/changelogs/fragments/openvpn_tls.yml
+++ b/changelogs/fragments/openvpn_tls.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - pfsense_openvpn_client/server - apply ``tls`` setting to config (https://github.com/pfsensible/core/issues/132)
+  - pfsense_openvpn_client - add ``tls_type`` parameter

--- a/plugins/modules/pfsense_openvpn_client.py
+++ b/plugins/modules/pfsense_openvpn_client.py
@@ -66,8 +66,15 @@ options:
     choices: [ 'tun', 'tap' ]
     type: str
   tls:
-    description: TLS Key.  If set to 'generate' it will create a key if one does not already exist.
+    description: TLS Key.  If set to 'generate' it will create a key if one does not already exist.  Not valid with p2p_shared_key mode.
     type: str
+  tls_type:
+    description: Use TLS for authentication ('auth') or encyprtion and authentication ('crypt').  Only used when tls is set.
+    default: 'auth'
+    required: false
+    choices: ["auth", "crypt"]
+    type: str
+    version_added: 0.6.2
   ca:
     description: Certificate Authority name.
     type: str

--- a/plugins/modules/pfsense_openvpn_server.py
+++ b/plugins/modules/pfsense_openvpn_server.py
@@ -66,10 +66,11 @@ options:
     choices: ['tun', 'tap']
     type: str
   tls:
-    description: TLS Key.  If set to 'generate' it will create a key if one does not already exist.
+    description: TLS Key.  If set to 'generate' it will create a key if one does not already exist.  Not valid with p2p_shared_key mode.
     type: str
   tls_type:
-    description: Use TLS for authentication ('auth') or encyprtion and authentication ('crypt').
+    description: Use TLS for authentication ('auth') or encyprtion and authentication ('crypt').  Only used when tls is set.
+    default: 'auth'
     required: false
     choices: ["auth", "crypt"]
     type: str

--- a/tests/unit/plugins/modules/test_pfsense_openvpn_server.py
+++ b/tests/unit/plugins/modules/test_pfsense_openvpn_server.py
@@ -109,6 +109,7 @@ class TestPFSenseOpenVPNServerModule(TestPFSenseModule):
             obj['shared_key'] = TLSKEY
         if 'tls' in obj and obj['tls'] == 'generate':
             obj['tls'] = TLSKEY
+            obj['tls_type'] = 'auth'
 
         self.check_param_equal(obj, target_elt, 'name', xml_field='description')
         self.check_param_equal(obj, target_elt, 'custom_options')


### PR DESCRIPTION
- pfsense_openvpn_client/server - apply `tls` setting to config (fixes #132)
- pfsense_openvpn_client - add `tls_type` parameter
- add some basic valied to complain if `tls` is used with `p2p_shared_key`