### PR TITLE
[pfsense] handle "."s prefixing php() output

### DIFF
--- a/changelogs/fragments/booting.yml
+++ b/changelogs/fragments/booting.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pfsense - handle "."s prefixing php() output triggered by the presense of /var/run/booting and issue a warning (https://github.com/pfsensible/core/issues/118)

--- a/plugins/module_utils/pfsense.py
+++ b/plugins/module_utils/pfsense.py
@@ -649,6 +649,10 @@ class PFSenseModule(object):
         cmd += command
         cmd += '\n?>\n'
         (dummy, stdout, stderr) = self.module.run_command('/usr/local/bin/php', data=cmd)
+        # If /var/run/booting is in place, various requires will emit a "."
+        (stdout, nsubs) = re.subn(r'^\.+', '', stdout)
+        if nsubs > 0:
+            self.module.warn('/var/run/booting appears to be present, confirm successful boot and remove if appropriate.')
         # TODO: check stderr for errors
         return json.loads(stdout)
 


### PR DESCRIPTION
triggered by the presense of /var/run/booting and issue a warning.

Fixes #118