### PR TITLE
_remove_all_separators() works when no separator exists

### DIFF
--- a/changelogs/fragments/170_pfsense_interface_fix_remove_all_separators.yml
+++ b/changelogs/fragments/170_pfsense_interface_fix_remove_all_separators.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - pfsense_interface - fixes removal of an interface with ``state: absent``. _remove_all_separators() works when no separator exists for that interface. (https://github.com/pfsensible/core/issues/170)
+  - "pfsense_interface - fixes removal of an interface with ``state: absent``. _remove_all_separators() works when no separator exists for that interface. (https://github.com/pfsensible/core/issues/170)"

--- a/changelogs/fragments/170_pfsense_interface_fix_remove_all_separators.yml
+++ b/changelogs/fragments/170_pfsense_interface_fix_remove_all_separators.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "pfsense_interface - fixes removal of an interface with ``state: absent``. _remove_all_separators() works when no separator exists for that interface. (https://github.com/pfsensible/core/issues/170)"
+  - "pfsense_interface - fixes removal of an interface with `state: absent`. _remove_all_separators() works when no separator exists for that interface. (https://github.com/pfsensible/core/issues/170)"

--- a/changelogs/fragments/170_pfsense_interface_fix_remove_all_separators.yml
+++ b/changelogs/fragments/170_pfsense_interface_fix_remove_all_separators.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pfsense_interface - fixes removal of an interface with ``state: absent``. _remove_all_separators() works when no separator exists for that interface. (https://github.com/pfsensible/core/issues/170)

--- a/plugins/module_utils/interface.py
+++ b/plugins/module_utils/interface.py
@@ -383,7 +383,7 @@ class PFSenseInterfaceModule(PFSenseModuleBase):
     def _remove_all_separators(self, interface):
         """ delete all interface separators """
         todel = []
-        separators = self.pfsense.rules.find('separator')
+        separators = self.pfsense.rules.find('separator') or []
         for interface_elt in separators:
             if interface_elt.tag != interface:
                 continue


### PR DESCRIPTION
Fixes #170 