### PR TITLE
[pfsense_user] Add support for disabling users

### DIFF
--- a/plugins/modules/pfsense_user.py
+++ b/plugins/modules/pfsense_user.py
@@ -230,7 +230,7 @@ class PFSenseUserModule(PFSenseModuleBase):
         self.diff['after'] = self.pfsense.element_to_dict(self.target_elt)
         if 'priv' in self.diff['after']:
             self.diff['after']['priv'] = self._format_diff_priv(self.diff['after']['priv'])
-        if self._remove_deleted_disabled_param(self):
+        if self._remove_deleted_disabled_param():
             changed = True
         if self._update_groups():
             changed = True


### PR DESCRIPTION
Adds the possibility to control if a user should be `disabled` or not. Useful for temporary changes or when you want to preserve the history of a user.

Example usage:
```yml
- name: Add operator user
  pfsense_user:
    name: operator
    descr: Operator

- name: Disable user
  pfsense_user:
    name: operator
    disabled: true
```