### PR TITLE
fix(pfsense_rule): properly validate ipv6

### DIFF
--- a/changelogs/fragemnts/219_parse_address_ipv6.yml
+++ b/changelogs/fragemnts/219_parse_address_ipv6.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pfsense_rule - Allow IPv6 addresses in source and destination (https://github.com/pfsensible/core/issues/219).

--- a/plugins/module_utils/__impl/addresses.py
+++ b/plugins/module_utils/__impl/addresses.py
@@ -103,9 +103,12 @@ def parse_ip_network(address, strict=True, returns_ip=True):
 
 def parse_address(self, param, allow_self=True):
     """ validate param address field and returns it as a dict """
-    addr = param.split(':')
-    if len(addr) > 3:
-        self.module.fail_json(msg='Cannot parse address %s' % (param))
+    if self.is_ipv6_address(param) or self.is_ipv6_network(param):
+        addr = [param]
+    else:
+        addr = param.split(':', maxsplit=3)
+        if len(addr) > 3:
+            self.module.fail_json(msg='Cannot parse address %s' % (param))
 
     address = addr[0]
 

--- a/tests/unit/plugins/modules/test_pfsense_rule.py
+++ b/tests/unit/plugins/modules/test_pfsense_rule.py
@@ -12,6 +12,7 @@ if sys.version_info < (2, 7):
 
 from ansible_collections.pfsensible.core.plugins.modules import pfsense_rule
 from ansible_collections.pfsensible.core.plugins.module_utils.rule import PFSenseRuleModule
+from ansible_collections.pfsensible.core.plugins.module_utils.__impl.addresses import is_ipv6_address, is_ipv6_network
 from .pfsense_module import TestPFSenseModule
 
 
@@ -31,7 +32,10 @@ class TestPFSenseRuleModule(TestPFSenseModule):
 
     def parse_address(self, addr):
         """ return address parsed in dict """
-        parts = addr.split(':')
+        if is_ipv6_address(addr) or is_ipv6_network(addr):
+            parts = [addr]
+        else:
+            parts = addr.split(':')
         res = {}
         if parts[0][0] == '!':
             res['not'] = None

--- a/tests/unit/plugins/modules/test_pfsense_rule_create.py
+++ b/tests/unit/plugins/modules/test_pfsense_rule_create.py
@@ -329,10 +329,22 @@ class TestPFSenseRuleCreateModule(TestPFSenseRuleModule):
         command = "create rule 'one_rule' on 'lan', source='10.10.1.1', destination='10.10.10.1'"
         self.do_module_test(obj, command=command)
 
+    def test_rule_create_ip6_to_ip6(self):
+        """ test creation of a new rule with valid ips """
+        obj = dict(name='one_rule', source='2001:db8:1::1', destination='2001:db8:2::2', ipprotocol='inet6', interface='lan')
+        command = "create rule 'one_rule' on 'lan', source='2001:db8:1::1', destination='2001:db8:2::2', ipprotocol='inet6'"
+        self.do_module_test(obj, command=command)
+
     def test_rule_create_net_to_net(self):
         """ test creation of a new rule valid networks """
         obj = dict(name='one_rule', source='10.10.1.0/24', destination='10.10.10.0/24', interface='lan')
         command = "create rule 'one_rule' on 'lan', source='10.10.1.0/24', destination='10.10.10.0/24'"
+        self.do_module_test(obj, command=command)
+
+    def test_rule_create_net6_to_net6(self):
+        """ test creation of a new rule valid networks """
+        obj = dict(name='one_rule', source='2001:db8:1::/64', destination='2001:db8:2::/64', ipprotocol='inet6', interface='lan')
+        command = "create rule 'one_rule' on 'lan', source='2001:db8:1::/64', destination='2001:db8:2::/64', ipprotocol='inet6'"
         self.do_module_test(obj, command=command)
 
     def test_rule_create_net_interface(self):


### PR DESCRIPTION
This PR solves #219. It probably solves similar issues on other modules with IP:port validation.

I first added tests to prove it didn't work with IPv6 network and IP.
Then implemented the fix.

This patch can surely be improved in some places, especially where duplicating code.
When `:port` syntax is dropped, this patch can probably be removed.

The new added tests now pass on my fork and I could test locally that it indeed fixes my issue.