### PR TITLE
Add is_ipv6_address validation to pfesnsible.core.pfsense_dns_resolver for hosts and domainoverrides

### DIFF
--- a/changelogs/fragments/226_dns_resolver.yaml
+++ b/changelogs/fragments/226_dns_resolver.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pfsense_dns_resolver - Allow IPv6 addresses for hosts and domainoverrides (https://github.com/pfsensible/core/pull/245).

--- a/plugins/modules/pfsense_dns_resolver.py
+++ b/plugins/modules/pfsense_dns_resolver.py
@@ -499,13 +499,13 @@ class PFSenseDNSResolverModule(PFSenseModuleBase):
 
         for host in params["hosts"]:
             for ipaddr in host["ip"].split(","):
-                if not self.pfsense.is_ipv4_address(ipaddr):
-                    self.module.fail_json(msg=f'ip, {ipaddr} is not a ipv4 address')
+                if not self.pfsense.is_ipv4_address(ipaddr) and not self.pfsense.is_ipv6_address(ipaddr):
+                    self.module.fail_json(msg=f'ip, {ipaddr} is not a ipv4/ipv6 address')
 
         if params["domainoverrides"] is not None:
             for domain in params["domainoverrides"]:
-                if not self.pfsense.is_ipv4_address(domain["ip"]):
-                    self.module.fail_json(msg=f'ip, {domain["ip"]} is not a ipv4 address')
+                if not self.pfsense.is_ipv4_address(domain["ip"]) and not self.pfsense.is_ipv6_address(domain["ip"]):
+                    self.module.fail_json(msg=f'ip, {domain["ip"]} is not a ipv4/ipv6 address')
 
     ##############################
     # XML processing


### PR DESCRIPTION
Add `is_ipv6_address` validation to `pfesnsible.core.pfsense_dns_resolver` for `hosts` and `domainoverrides`

Even though the documentation indicates that `['hosts']['ip']` `['domainoverrides']['ip']` allows for IPv6, the code validation does not.   Simply permit both IPv4 and IPv6, as per the documentation:

Documentation (commit as of today) stating IPv6 is allowed:

- https://github.com/pfsensible/core/blob/eba1c3a7a64097048e9360a6cd1c30617c0d31db/plugins/modules/pfsense_dns_resolver.py#L123
- https://github.com/pfsensible/core/blob/eba1c3a7a64097048e9360a6cd1c30617c0d31db/plugins/modules/pfsense_dns_resolver.py#L161