### PR TITLE
Add support for setting Strict Outgoing Network Interface Binding (strictout)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ pfSensible.Core Release Notes
 
 .. contents:: Topics
 
+v0.7.2
+======
+
+Minor Changes
+-------------
+
+- pfsense_dns_resolver - Add ability to set Strict Outgoing Network Interface Binding (https://github.com/pfsensible/core/issues/254).
+
 v0.7.1
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,11 +7,6 @@ pfSensible.Core Release Notes
 v0.7.2
 ======
 
-Minor Changes
--------------
-
-- pfsense_dns_resolver - Add ability to set Strict Outgoing Network Interface Binding (https://github.com/pfsensible/core/issues/254).
-
 v0.7.1
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,6 @@ pfSensible.Core Release Notes
 
 .. contents:: Topics
 
-v0.7.2
-======
-
 v0.7.1
 ======
 

--- a/changelogs/fragments/254_dns_resolver_strictout.yaml
+++ b/changelogs/fragments/254_dns_resolver_strictout.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pfsense_dns_resolver -  Add ability to set Strict Outgoing Network Interface Binding (https://github.com/pfsensible/core/pull/254).

--- a/plugins/modules/pfsense_dns_resolver.py
+++ b/plugins/modules/pfsense_dns_resolver.py
@@ -70,6 +70,7 @@ options:
     required: false
     default: false
     type: bool
+    version_added: 0.7.2
   system_domain_local_zone_type:
     description: The local-zone type used for the pfSense system domain.
     required: false

--- a/plugins/modules/pfsense_dns_resolver.py
+++ b/plugins/modules/pfsense_dns_resolver.py
@@ -63,6 +63,13 @@ options:
     default: [ "all" ]
     type: list
     elements: str
+  strictout:
+    description: 
+      - Strict Outgoing Network Interface Binding.
+      - Do not send recursive queries if none of the Outgoing Network Interfaces are available.
+    required: false
+    default: false
+    type: bool
   system_domain_local_zone_type:
     description: The local-zone type used for the pfSense system domain.
     required: false
@@ -338,7 +345,7 @@ DNS_RESOLVER_ARGUMENT_SPEC = dict(
     tlsport=dict(default=None, type='int'),
     active_interface=dict(default=["all"], type='list', elements='str'),
     outgoing_interface=dict(default=["all"], type='list', elements='str'),
-    # TODO: Strict Outgoing Network interface Binding: check box option
+    strictout=dict(default=False, type='bool'),
     system_domain_local_zone_type=dict(default='transparent', choices=['deny', 'refuse', 'static', 'transparent', 'typetransparent', 'redirect', 'inform',
                                                                        'inform_deny', 'nodefault']),
     dnssec=dict(default=True, type='bool'),
@@ -455,6 +462,7 @@ class PFSenseDNSResolverModule(PFSenseModuleBase):
             self._get_ansible_param_bool(obj, "forward_tls_upstream", value="")
             self._get_ansible_param_bool(obj, "prefetch", value="")
             self._get_ansible_param_bool(obj, "prefetchkey", value="")
+            self._get_ansible_param_bool(obj, "strictout", value="")
             self._get_ansible_param(obj, "msgcachesize")
             self._get_ansible_param(obj, "outgoing_num_tcp")
             self._get_ansible_param(obj, "incoming_num_tcp")
@@ -524,7 +532,7 @@ class PFSenseDNSResolverModule(PFSenseModuleBase):
             return ["enable"]
         else:
             return ["hideidentity", "hideversion", "dnssecstripped", "forwarding", "regdhcp", "regdhcpstatic", "regovpnclients", "enablessl", "dnssec",
-                    "forward_tls_upstream", "prefetch", "prefetchkey"]
+                    "forward_tls_upstream", "prefetch", "prefetchkey", "strictout"]
 
     ##############################
     # run
@@ -564,6 +572,7 @@ clear_subsystem_dirty("unbound");
         values += self.format_updated_cli_field(self.obj, before, 'tlsport', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)
         values += self.format_updated_cli_field(self.obj, before, 'sslcertref', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)
         values += self.format_updated_cli_field(self.obj, before, 'forwarding', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)
+        values += self.format_updated_cli_field(self.obj, before, 'strictout', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)
         values += self.format_updated_cli_field(self.obj, before, 'system_domain_local_zone_type', add_comma=(values), log_none=False)
         values += self.format_updated_cli_field(self.obj, before, 'regdhcp', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)
         values += self.format_updated_cli_field(self.obj, before, 'regdhcpstatic', fvalue=self.fvalue_bool, add_comma=(values), log_none=False)

--- a/plugins/modules/pfsense_dns_resolver.py
+++ b/plugins/modules/pfsense_dns_resolver.py
@@ -68,7 +68,6 @@ options:
       - Strict Outgoing Network Interface Binding.
       - Do not send recursive queries if none of the Outgoing Network Interfaces are available.
     required: false
-    default: false
     type: bool
     version_added: 0.7.2
   system_domain_local_zone_type:
@@ -346,7 +345,7 @@ DNS_RESOLVER_ARGUMENT_SPEC = dict(
     tlsport=dict(default=None, type='int'),
     active_interface=dict(default=["all"], type='list', elements='str'),
     outgoing_interface=dict(default=["all"], type='list', elements='str'),
-    strictout=dict(default=False, type='bool'),
+    strictout=dict(type='bool'),
     system_domain_local_zone_type=dict(default='transparent', choices=['deny', 'refuse', 'static', 'transparent', 'typetransparent', 'redirect', 'inform',
                                                                        'inform_deny', 'nodefault']),
     dnssec=dict(default=True, type='bool'),

--- a/plugins/modules/pfsense_dns_resolver.py
+++ b/plugins/modules/pfsense_dns_resolver.py
@@ -64,7 +64,7 @@ options:
     type: list
     elements: str
   strictout:
-    description: 
+    description:
       - Strict Outgoing Network Interface Binding.
       - Do not send recursive queries if none of the Outgoing Network Interfaces are available.
     required: false

--- a/tests/unit/plugins/modules/test_pfsense_dns_resolver.py
+++ b/tests/unit/plugins/modules/test_pfsense_dns_resolver.py
@@ -39,6 +39,7 @@ class TestPFSenseDNSResolverModule(TestPFSenseModule):
         # self.check_param_equal(obj, target_elt, 'active_interface')
         # self.check_param_equal(obj, target_elt, 'outgoing_interface')
         # self.check_param_equal(obj, target_elt, 'system_domain_local_zone_type')
+        self.check_param_bool(obj, target_elt, 'strictout', default=False)
         self.check_param_bool(obj, target_elt, 'dnssec', default=True)
         self.check_param_bool(obj, target_elt, 'forwarding')
         self.check_param_bool(obj, target_elt, 'forward_tls_upstream')

--- a/tests/unit/plugins/modules/test_pfsense_dns_resolver.py
+++ b/tests/unit/plugins/modules/test_pfsense_dns_resolver.py
@@ -39,7 +39,7 @@ class TestPFSenseDNSResolverModule(TestPFSenseModule):
         # self.check_param_equal(obj, target_elt, 'active_interface')
         # self.check_param_equal(obj, target_elt, 'outgoing_interface')
         # self.check_param_equal(obj, target_elt, 'system_domain_local_zone_type')
-        self.check_param_bool(obj, target_elt, 'strictout', default=False)
+        self.check_param_bool(obj, target_elt, 'strictout')
         self.check_param_bool(obj, target_elt, 'dnssec', default=True)
         self.check_param_bool(obj, target_elt, 'forwarding')
         self.check_param_bool(obj, target_elt, 'forward_tls_upstream')


### PR DESCRIPTION
Adding support in the pfsense_dns_resolver module for the attribute strictout, which basically is the option "Strict Outgoing Network Interface Binding".

strictout is a boolean value, defaults to false.

