### PR TITLE
Fix wrong external 'caref' at System/Certificates/Authorities

### DIFF
--- a/plugins/modules/pfsense_ca.py
+++ b/plugins/modules/pfsense_ca.py
@@ -422,17 +422,18 @@ class PFSenseCAModule(PFSenseModuleBase):
         (dummy, stdout, stderr) = ('', '', '')
         if self.params['state'] == 'present':
             if self.params['method'] == 'existing':
-                # ca_import will base64 encode the cert + key  and will fix 'caref' for CAs that reference each other
+                # ca_import will base64 encode the cert + key and will fix 'caref' for CAs that reference each other
                 # $ca needs to be an existing reference (particularly 'refid' must be set) before calling ca_import
-                # key and serial are optional arguments.  TODO - handle key and serial
+                # key and serial are optional arguments. TODO - handle key and serial
                 (dummy, stdout, stderr) = self.pfsense.phpshell("""
-                    $ca =& lookup_ca('{refid}')['item'];
+                    $caent =& lookup_ca('{refid}');
+                    $ca =& $caent['item'];
                     ca_import($ca, '{cert}');
+                    config_set_path("ca/{{$caent['idx']}}", $ca);
                     write_config('Update CA reference');
                     ca_setup_trust_store();
                     cert_restart_services(ca_get_all_services('{refid}'));""".format(refid=self.target_elt.find('refid').text,
                                                                                      cert=base64.b64decode(self.target_elt.find('crt').text.encode()).decode()))
-
                 if self.refresh_crls:
                     (dummy, crl_stdout, crl_stderr) = self.pfsense.phpshell("""
                         require_once("openvpn.inc");

--- a/plugins/modules/pfsense_cert.py
+++ b/plugins/modules/pfsense_cert.py
@@ -340,17 +340,24 @@ class PFSenseCertModule(PFSenseModuleBase):
     def _update(self):
         if self.params['state'] == 'present':
             if self.params['method'] == 'import':
+                prv_node = self.target_elt.find('prv')
+                raw_key = base64.b64decode(prv_node.text.encode()).decode() if (prv_node is not None and prv_node.text) else ""
                 # import certificate
                 return self.pfsense.phpshell("""
                     require_once('certs.inc');
-                    $cert =& lookup_cert('{refid}');
+                    $certent = lookup_cert('{refid}');
+                    $cert = $certent['item'];
+
                     cert_import($cert, '{cert}', '{key}');
+
+                    config_set_path("cert/{{$certent['idx']}}", $cert);
+
                     $savemsg = sprintf(gettext("Imported certificate %s"), $cert['descr']);
                     write_config($savemsg);
                     cert_restart_services(cert_get_all_services('{refid}'));
                     """.format(refid=self.target_elt.find('refid').text,
                                cert=base64.b64decode(self.target_elt.find('crt').text.encode()).decode(),
-                               key=base64.b64decode(self.target_elt.find('prv').text.encode()).decode()))
+                               key=raw_key))
             else:
                 # generate internal certificate
                 return self.pfsense.phpshell("""

--- a/plugins/modules/pfsense_cert.py
+++ b/plugins/modules/pfsense_cert.py
@@ -347,11 +347,8 @@ class PFSenseCertModule(PFSenseModuleBase):
                     require_once('certs.inc');
                     $certent = lookup_cert('{refid}');
                     $cert = $certent['item'];
-
                     cert_import($cert, '{cert}', '{key}');
-
                     config_set_path("cert/{{$certent['idx']}}", $cert);
-
                     $savemsg = sprintf(gettext("Imported certificate %s"), $cert['descr']);
                     write_config($savemsg);
                     cert_restart_services(cert_get_all_services('{refid}'));


### PR DESCRIPTION
The actual `pfsense_ca.py` fails to identify Issuer of an INTCA. Even then the RootCA is correctly present and imported, the INTCA Issuer will be refered as `external` instead of the already imported RootCA Name.

In pfSense, the link between a parent Certificate Authority (CA) and an intermediate (child) CA is established via the caref field (which contains the parent's REFID). If this field is absent or empty, pfSense considers the issuer to be `external`.

When you use the graphical interface (`system_camanager.php`), the configuration modified by the PHP functions is explicitly injected back into the global configuration tree via `config_set_path()`:
Here is how it's done:
```
<?php
$pluginparams = array();
$pluginparams['type'] = 'certificates';
$pluginparams['event'] = 'used_ca';
$certificates_used_by_packages = pkg_call_plugins('plugin_certificates', $pluginparams);

foreach (config_get_path('ca', []) as $ca):
	$name = htmlspecialchars($ca['descr']);
	$subj = cert_get_subject($ca['crt']);
	$issuer = cert_get_issuer($ca['crt']);
	if ($subj == $issuer) {
		$issuer_name = gettext("self-signed");
	} else {
		$issuer_name = gettext("external");
	}
	$subj = htmlspecialchars(cert_escape_x509_chars($subj, true));
	$issuer = htmlspecialchars($issuer);
	$certcount = 0;

	$issuer_ca = lookup_ca($ca['caref']);
	$issuer_ca = $issuer_ca['item'];
	if ($issuer_ca) {
		$issuer_name = htmlspecialchars($issuer_ca['descr']);
	}

	foreach (config_get_path('cert', []) as $cert) {
		if ($cert['caref'] == $ca['refid']) {
			$certcount++;
		}
	}

	foreach (config_get_path('ca', []) as $cert) {
		if ($cert['caref'] == $ca['refid']) {
			$certcount++;
		}
	}
?>
```

However, in the existing method of `pfsense_ca.py` file, the script correctly calls `ca_import($ca, ...)` (which parses the certificate and binds the caref in memory), but it fails to save this updated object in the configuration. The modification remains volatile, and `write_config()` does not save anything new.

To fix that we then locate the _update() function and modify the block to retrieve the configuration index (`$caent`) and apply `config_set_path()`, exactly as already done below for the internal method.